### PR TITLE
bug/5438-unable-to-install-otvision-with-install-script

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -10,5 +10,6 @@ if "x%PYTHON_VERSION:3.10=%"=="x%PYTHON_VERSION%" (
 python -m venv venv
 call venv\Scripts\activate
 python -m pip install --upgrade pip
+pip install --upgrade pip-tools pip wheel
 pip install -r requirements.txt --no-cache-dir%
 deactivate

--- a/install.sh
+++ b/install.sh
@@ -11,5 +11,4 @@ python3.10 -m venv "$VENV"
 
 $PYTHON -m pip install --upgrade pip
 $PIP install --upgrade pip-tools pip wheel
-#$PIP install setuptools==71.1.0
 $PIP install -r requirements.txt --no-cache-dir

--- a/install.sh
+++ b/install.sh
@@ -10,4 +10,6 @@ PIP="$VENV"/bin/pip
 python3.10 -m venv "$VENV"
 
 $PYTHON -m pip install --upgrade pip
+$PIP install --upgrade pip-tools pip wheel
+#$PIP install setuptools==71.1.0
 $PIP install -r requirements.txt --no-cache-dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ psutil==5.9.5
 pyogrio==0.5.1
 PyYAML==6.0
 seaborn==0.12.2
+setuptools==71.1.0
 # Follow instructions at https://pytorch.org to install torch with CUDA
 torch==2.1.2 #  NOTE: Omit if using torch with CUDA and install manually
 torchvision==0.16.2 # NOTE: Omit if using torch with CUDA and install manually


### PR DESCRIPTION
moviepy does not work with setuptools>=72 since it still depends on the deprecated TestCommand class which has been removed in setuptools>=72.  Use setuptools==71.1.0 until the maintainers of moviepy have fixed this issue.