### PR TITLE
bug/7533-inference-on-with-otvision-cuda-when-installing-with-uv-fails 

### DIFF
--- a/OTVision/detect/cli.py
+++ b/OTVision/detect/cli.py
@@ -110,8 +110,8 @@ class ArgparseDetectCliParser(DetectCliParser):
             "--start-time",
             default=None,
             type=str,
-            help=f"Specify start date and time of the recording in format "
-            f"{DATETIME_FORMAT}.",
+            help="Specify start date and time of the recording in format "
+            "YYYY-MM-DD_HH-MM-SS",
             required=False,
         )
         self._parser.add_argument(
@@ -130,6 +130,8 @@ class ArgparseDetectCliParser(DetectCliParser):
         )
 
     def parse(self) -> DetectCliArgs:
+        print("Argv")
+        print(self._argv)
         args = self._parser.parse_args(self._argv)
         self.__assert_cli_args_valid(args)
 

--- a/config.yml
+++ b/config.yml
@@ -35,12 +35,19 @@ configurations:
     suffix: "win-cuda"
     output_file_name: otvision
     additional_requirements:
+      - "--extra-index-url https://pypi.nvidia.com/"
       - "--extra-index-url https://download.pytorch.org/whl/cu126"
+      - "tensorrt==10.9.0.34"
+      - "tensorrt-cu12-bindings==10.9.0.34"
+      - "tensorrt-cu12-libs==10.9.0.34"
   - package_path: OTVision
     files:
       - source: "install.sh"
     suffix: "linux-cuda"
     output_file_name: OTVision
     additional_requirements:
+      - "--extra-index-url https://pypi.nvidia.com/"
       - "--extra-index-url https://download.pytorch.org/whl/cu126"
-      - "tensorrt==10.8.0.43"
+      - "tensorrt==10.9.0.34"
+      - "tensorrt-cu12-bindings==10.9.0.34"
+      - "tensorrt-cu12-libs==10.9.0.34"

--- a/install.cmd
+++ b/install.cmd
@@ -12,5 +12,5 @@ call .venv\Scripts\activate
 python -m pip install --upgrade pip
 pip install uv
 uv pip install --upgrade pip-tools pip wheel
-uv pip install -r requirements.txt --index-strategy unsafe-first-match%
+uv pip install -r requirements.txt --index-strategy unsafe-first-match --python .venv%
 deactivate

--- a/install.cmd
+++ b/install.cmd
@@ -12,5 +12,5 @@ call .venv\Scripts\activate
 python -m pip install --upgrade pip
 pip install uv
 uv pip install --upgrade pip-tools pip wheel
-uv pip install -r requirements.txt --index-strategy unsafe-first-match --python .venv%
+uv pip install -r requirements.txt --index-strategy unsafe-best-match --python .venv%
 deactivate

--- a/install.sh
+++ b/install.sh
@@ -23,4 +23,4 @@ python3.12 -m venv "$VENV"
 
 $PYTHON -m pip install --upgrade pip
 $PIP install uv
-$UV pip install -r requirements.txt --index-strategy unsafe-first-match --python .venv
+$UV pip install -r requirements.txt --index-strategy unsafe-best-match --python .venv

--- a/install.sh
+++ b/install.sh
@@ -23,4 +23,4 @@ python3.12 -m venv "$VENV"
 
 $PYTHON -m pip install --upgrade pip
 $PIP install uv
-$UV pip install -r requirements.txt --index-strategy unsafe-first-match
+$UV pip install -r requirements.txt --index-strategy unsafe-first-match --python .venv

--- a/install_dev.cmd
+++ b/install_dev.cmd
@@ -1,6 +1,6 @@
 echo Install OTVision development environment.
 call install.cmd
 call .venv\Scripts\activate
-uv pip install -r requirements-dev.txt%
+uv pip install -r requirements-dev.txt --python .venv%
 pre-commit install --install-hooks
 deactivate

--- a/install_dev.sh
+++ b/install_dev.sh
@@ -9,5 +9,5 @@ UV="$VENV"/bin/uv
 
 bash "$WORKING_DIR"/install.sh
 
-$UV pip install -r requirements-dev.txt
+$UV pip install -r requirements-dev.txt --python .venv
 $PRE_COMMIT install --install-hooks


### PR DESCRIPTION
### Description

This pull request introduces improvements and fixes to address multiple issues:

- **Change index strategy to `unsafe-best-match`:** Ensures the best match is used when dealing with multiple extra indexes during installation of OTVision.
- **Specify virtual environment for dependency installation:** Fixes incorrect installation of OTVision dependencies in third-party environments like OTCloud by explicitly specifying the correct `.venv`.
- **Resolve missing TensorRT dependencies in GPU usage:** Addresses missing `tensorrt_bindings` by specifying required packages from the NVIDIA PyPI index and upgrading the TensorRT library to version 10.9.0.34.
- **Fix CLI help flag issue:** Corrects an escaping issue in the `--start-time` option, allowing help text to render properly.

OP#7533