### PR TITLE
Improve memory handling in DetectedFrameBuffer

### DIFF
--- a/OTVision/application/buffer.py
+++ b/OTVision/application/buffer.py
@@ -22,7 +22,8 @@ class Buffer[T, SUBJECT_TYPE, OBSERVING_TYPE](Observable[SUBJECT_TYPE], Filter[T
         return self._buffer
 
     def _reset_buffer(self) -> None:
-        self._buffer = []
+        del self._buffer
+        self._buffer = list()
 
     def on_flush(self, event: OBSERVING_TYPE) -> None:
         buffered_elements = self._get_buffered_elements()

--- a/OTVision/detect/detected_frame_buffer.py
+++ b/OTVision/detect/detected_frame_buffer.py
@@ -55,3 +55,6 @@ class DetectedFrameBuffer(Buffer[DetectedFrame, DetectedFrameBufferEvent, FlushE
                 source_metadata=event.source_metadata, frames=elements
             )
         )
+
+    def buffer(self, to_buffer: DetectedFrame) -> None:
+        self._buffer.append(to_buffer.without_image())

--- a/OTVision/detect/video_input_source.py
+++ b/OTVision/detect/video_input_source.py
@@ -7,7 +7,6 @@ import av
 from tqdm import tqdm
 
 from OTVision.abstraction.observer import Subject
-from OTVision.application.configure_logger import logger
 from OTVision.application.detect.detection_file_save_path_provider import (
     DetectionFileSavePathProvider,
 )
@@ -130,7 +129,7 @@ class VideoSource(InputSourceDetect):
                         counter += 1
                 self.notify_observers(video_file, video_fps)
             except Exception as e:
-                logger().error(f"Error processing {video_file}", exc_info=e)
+                log.error(f"Error processing {video_file}", exc_info=e)
 
     def __collect_files_to_detect(self) -> list[Path]:
         filetypes = self._current_config.filetypes.video_filetypes.to_list()

--- a/OTVision/domain/frame.py
+++ b/OTVision/domain/frame.py
@@ -59,6 +59,15 @@ class DetectedFrame:
     detections: Sequence[Detection]
     image: Optional[ndarray] = None
 
+    def without_image(self) -> "DetectedFrame":
+        return DetectedFrame(
+            no=self.no,
+            occurrence=self.occurrence,
+            source=self.source,
+            detections=self.detections,
+            image=None,
+        )
+
 
 IsLastFrame = Callable[[FrameNo, TrackId], bool]
 

--- a/tests/detect/test_detected_frame_buffer.py
+++ b/tests/detect/test_detected_frame_buffer.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
@@ -8,6 +9,7 @@ from OTVision.detect.detected_frame_buffer import (
     DetectedFrameBufferEvent,
     FlushEvent,
 )
+from OTVision.domain.detection import Detection
 from OTVision.domain.frame import DetectedFrame
 from tests.utils.mocking import create_mocks
 
@@ -35,3 +37,35 @@ class TestDetectedFrameBuffer:
         )
         subject_mock.notify.assert_called_once_with(expected_event)
         assert target._get_buffered_elements() == []
+
+    def test_frames_are_buffered_without_image_data(
+        self, target: DetectedFrameBuffer
+    ) -> None:
+        """
+        #Bug https://openproject.platomo.de/projects/001-opentrafficcam-live/work_packages/7623
+        """  # noqa
+        frame_number = 1
+        occurrence = datetime(2020, 1, 1, 12, 0, 0)
+        source = "my_source"
+        detections: list[Detection] = create_mocks(3)
+        image = Mock()
+
+        given_frame = DetectedFrame(
+            no=frame_number,
+            occurrence=occurrence,
+            source=source,
+            detections=detections,
+            image=image,
+        )
+        target.buffer(given_frame)
+        actual = target._get_buffered_elements()[0]
+
+        expected = DetectedFrame(
+            no=frame_number,
+            occurrence=occurrence,
+            source=source,
+            detections=detections,
+            image=None,
+        )
+
+        assert actual == expected


### PR DESCRIPTION
### Description

This pull request introduces improvements to the memory handling within `DetectedFrameBuffer`:

- Added a `buffer` method to allow storing frames without image data, enhancing memory efficiency.
- Introduced a `without_image` method in `DetectedFrame` to support the above functionality.
- Modified buffer resetting using `del` to ensure proper memory release and facilitate better garbage collection.
- Fixed a logger statement.

Tests were added to confirm the correctness of buffering frames without image data

OP#7623