### PR TITLE
bug/9257-otvisionremoteworker-with-ftp-enabled-does-not-upload-otvision-result-files-anymore

### DIFF
--- a/OTVision/detect/video_input_source.py
+++ b/OTVision/detect/video_input_source.py
@@ -220,6 +220,7 @@ class VideoSource(InputSourceDetect):
                 start_time=start_time,
             )
         )
+        await self.subject_flush.wait_for_all_observers()
 
     def notify_new_video_start_observers(
         self, current_video_file: Path, video_fps: float


### PR DESCRIPTION
Ensures all observers finish after a flush event before the next video is processed in `VideoSource`.

OP#9257