### PR TITLE
Fix reindex shifting ottrk frame numbers to the first detection

### DIFF
--- a/OTVision/track/exporter/filebased_exporter.py
+++ b/OTVision/track/exporter/filebased_exporter.py
@@ -23,3 +23,8 @@ class FinishedChunkTrackExporter(FinishedTracksExporter[FinishedChunk]):
 
     def get_frame_group_id(self, container: FinishedChunk) -> int:
         return container.frame_group_id
+
+    def get_first_frame_no(self, container: FinishedChunk) -> int:
+        if not container.frames:
+            return 1
+        return min(frame.no for frame in container.frames)

--- a/OTVision/track/model/track_exporter.py
+++ b/OTVision/track/model/track_exporter.py
@@ -48,6 +48,15 @@ class FinishedTracksExporter(ABC, Generic[F]):
     def get_frame_group_id(self, container: F) -> int:
         pass
 
+    @abstractmethod
+    def get_first_frame_no(self, container: F) -> int:
+        """Frame no of the container's first frame (with or without detections).
+
+        Used to rebase global frame group frame numbers back to the local
+        frame numbering of the container's source video.
+        """
+        pass
+
     async def export(
         self, tracking_run_id: str, stream: AsyncIterator[F], overwrite: bool
     ) -> None:
@@ -59,7 +68,9 @@ class FinishedTracksExporter(ABC, Generic[F]):
     ) -> None:
         file_path = self.get_result_path(container)
 
-        det_dicts = self.reindex(self.get_detection_dicts(container))
+        det_dicts = self.reindex(
+            self.get_detection_dicts(container), self.get_first_frame_no(container)
+        )
 
         output = self.build_output(
             det_dicts,
@@ -78,11 +89,9 @@ class FinishedTracksExporter(ABC, Generic[F]):
         log.info(f"Successfully tracked and wrote {file_path}")
 
     @staticmethod
-    def reindex(det_dicts: list[dict]) -> list[dict]:
+    def reindex(det_dicts: list[dict], first_frame_no: int) -> list[dict]:
         if len(det_dicts) == 0:
             return []
-
-        min_frame_no = min(det[FRAME] for det in det_dicts)
 
         det_dicts_progress = tqdm(
             det_dicts,
@@ -91,7 +100,7 @@ class FinishedTracksExporter(ABC, Generic[F]):
             leave=False,
         )
         reindexed_dets = [
-            {**det, **{FRAME: det[FRAME] - min_frame_no + 1}}
+            {**det, **{FRAME: det[FRAME] - first_frame_no + 1}}
             for det in det_dicts_progress
         ]
 

--- a/tests/track/test_track_exporter.py
+++ b/tests/track/test_track_exporter.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Sequence
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from OTVision.dataformat import DATA, DETECTIONS, FRAME
 from OTVision.domain.detection import FinishedDetection
@@ -47,7 +47,7 @@ def create_frame(
 class TestFinishedChunkTrackExporter:
     @patch("OTVision.track.model.track_exporter.write_json")
     def test_reindex_rebases_frames_to_video_not_to_first_detection(
-        self, mock_write_json: patch
+        self, mock_write_json: MagicMock
     ) -> None:
         """Detection frame numbers in the written ottrk must match the source
         video's frame numbering. The chunk's first frames have no detections,
@@ -75,7 +75,7 @@ class TestFinishedChunkTrackExporter:
 
     @patch("OTVision.track.model.track_exporter.write_json")
     def test_export_chunk_without_detections_writes_empty_detections(
-        self, mock_write_json: patch
+        self, mock_write_json: MagicMock
     ) -> None:
         chunk = FinishedChunk(
             file=Path("video.otdet"),

--- a/tests/track/test_track_exporter.py
+++ b/tests/track/test_track_exporter.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Sequence
+from unittest.mock import patch
+
+from OTVision.dataformat import DATA, DETECTIONS, FRAME
+from OTVision.domain.detection import FinishedDetection
+from OTVision.domain.frame import FinishedFrame
+from OTVision.track.exporter.filebased_exporter import FinishedChunkTrackExporter
+from OTVision.track.model.filebased.frame_chunk import FinishedChunk
+
+VIDEO_START = datetime(2026, 6, 24, 10, 0, 0)
+FPS = 20.0
+FIRST_GLOBAL_FRAME_NO = 101  # chunk is not the first file of its frame group
+
+
+def create_detection(track_id: int) -> FinishedDetection:
+    return FinishedDetection(
+        label="car",
+        conf=0.9,
+        x=1.0,
+        y=2.0,
+        w=3.0,
+        h=4.0,
+        is_first=False,
+        track_id=track_id,
+        is_last=False,
+        is_discarded=False,
+    )
+
+
+def create_frame(
+    global_no: int, detections: Sequence[FinishedDetection]
+) -> FinishedFrame:
+    local_frame_index = global_no - FIRST_GLOBAL_FRAME_NO
+    return FinishedFrame(
+        no=global_no,
+        occurrence=VIDEO_START + timedelta(seconds=local_frame_index / FPS),
+        source="video.otdet",
+        output="video.otdet",
+        detections=detections,
+        finished_tracks=set(),
+        discarded_tracks=set(),
+    )
+
+
+class TestFinishedChunkTrackExporter:
+    @patch("OTVision.track.model.track_exporter.write_json")
+    def test_reindex_rebases_frames_to_video_not_to_first_detection(
+        self, mock_write_json: patch
+    ) -> None:
+        """Detection frame numbers in the written ottrk must match the source
+        video's frame numbering. The chunk's first frames have no detections,
+        so rebasing by the first detection would wrongly shift all frame
+        numbers towards 1 while occurrence stays at wall clock time."""
+        chunk = FinishedChunk(
+            file=Path("video.otdet"),
+            metadata={"tracking": {}},
+            is_last_chunk=False,
+            frames=[
+                create_frame(101, []),  # video frame 1: no detections
+                create_frame(102, [create_detection(1)]),  # video frame 2
+                create_frame(103, [create_detection(1)]),  # video frame 3
+            ],
+            frame_group_id=1,
+        )
+
+        FinishedChunkTrackExporter().export_frames(
+            chunk, tracking_run_id="run", overwrite=True
+        )
+
+        written = mock_write_json.call_args.kwargs["dict_to_write"]
+        written_frame_nos = [det[FRAME] for det in written[DATA][DETECTIONS]]
+        assert written_frame_nos == [2, 3]
+
+    @patch("OTVision.track.model.track_exporter.write_json")
+    def test_export_chunk_without_detections_writes_empty_detections(
+        self, mock_write_json: patch
+    ) -> None:
+        chunk = FinishedChunk(
+            file=Path("video.otdet"),
+            metadata={"tracking": {}},
+            is_last_chunk=False,
+            frames=[create_frame(101, [])],
+            frame_group_id=1,
+        )
+
+        FinishedChunkTrackExporter().export_frames(
+            chunk, tracking_run_id="run", overwrite=True
+        )
+
+        written = mock_write_json.call_args.kwargs["dict_to_write"]
+        assert written[DATA][DETECTIONS] == []


### PR DESCRIPTION
## Bug

`FinishedTracksExporter.reindex()` rebases detection frame numbers using the minimum frame number **that has a detection**:

```python
min_frame_no = min(det[FRAME] for det in det_dicts)
...
{**det, **{FRAME: det[FRAME] - min_frame_no + 1}}
```

If the first detection of a video occurs after frame 1, every frame number in the written `.ottrk` is shifted towards 1, while `occurrence` keeps correct wall clock time — `frame` and `occurrence` then disagree by exactly the time of the file's first detection.

## Impact

- Any tracked video whose first (surviving) detection is not in frame 1 gets inconsistent frame numbers. On low-traffic recordings (e.g. night-time 15-min segments) we observed shifts of 10 s up to several minutes.
- In OTAnalytics the track overlay renders too early relative to the video: the first track appears at the very start of the video regardless of when it actually occurred.
- The `number_of_frames` metadata no longer matches the maximum written frame number.

## Fix

Rebase by the chunk's **first frame number** (chunk frames include frames without detections), so written frame numbers always match the source video's frame numbering:

- new abstract `get_first_frame_no(container)` on `FinishedTracksExporter`
- `FinishedChunkTrackExporter` implements it as `min(frame.no for frame in container.frames)`
- `reindex(det_dicts, first_frame_no)` uses it instead of the per-detection minimum

## Tests

- New `tests/track/test_track_exporter.py`:
  - a chunk whose first frame has no detections must keep video frame numbers (fails on `main` with `[1, 2] != [2, 3]`, passes with the fix)
  - a chunk without any detections still writes an empty detection list (guards the OP#9383 behaviour)
- `tests/track` suite green; `mypy`, `black`, `isort`, `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

OP#9976